### PR TITLE
sendCreateMessage: Include port in targetDomain

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -108,7 +108,7 @@ function sendCreateMessage(text, name, domain, req, res) {
     for (let follower of followers) {
       let inbox = follower+'/inbox';
       let myURL = new URL(follower);
-      let targetDomain = myURL.hostname;
+      let targetDomain = myURL.host;
       let message = createMessage(text, name, domain, req, res, follower);
       signAndSend(message, name, domain, req, res, targetDomain, inbox);
     }


### PR DESCRIPTION
`url.hostname` excludes port, `url.host` includes it.