### PR TITLE
closing crypto.generateKeyPair() properly

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -68,6 +68,7 @@ router.post('/create', function (req, res) {
     catch(e) {
       res.status(200).json({error: e});
     }
+  });
 });
 
 module.exports = router;


### PR DESCRIPTION
After cloning the repository motivated by https://hacks.mozilla.org/2018/11/decentralizing-social-interactions-with-activitypub/ a syntax error on this file prevented from running the server. Closing crypto.generateKeyPair() properly seemed to prevent the error and the server seems to run properly.