### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "better-sqlite3": "^5.4.0",
-    "body-parser": "^1.18.3",
-    "cors": "^2.8.4",
-    "express": "^4.16.3",
-    "express-basic-auth": "^1.1.5",
+    "better-sqlite3": "^7.5.0",
+    "body-parser": "^1.19.1",
+    "cors": "^2.8.5",
+    "express": "^4.17.2",
+    "express-basic-auth": "^1.2.1",
     "request": "^2.87.0"
   },
   "engines": {


### PR DESCRIPTION
When I tried running `npm i` using Node 17.3.0 on macOS, I got a bunch of errors related to node-gyp. Updating the dependencies solved this.